### PR TITLE
Add EXPOSE directives for TURN server port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM scratch
 COPY screego /screego
+EXPOSE 3478/tcp
+EXPOSE 3478/udp
 EXPOSE 5050
 WORKDIR "/"
 ENTRYPOINT [ "/screego" ]


### PR DESCRIPTION
> The EXPOSE instruction informs Docker that the container listens on the specified network ports at runtime. You can specify whether the port listens on TCP or UDP, and the default is TCP if the protocol is not specified.

**Source:** https://docs.docker.com/engine/reference/builder/#expose