### PR TITLE
Push unstable Docker images on every commit to master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,3 +48,8 @@ jobs:
         env:
           DOCKER_USER: ${{ secrets.DOCKER_USER }}
           DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
+      - if: startsWith(github.ref, 'refs/heads/master')
+        run: make docker-manifest-annotate-unstable docker-manifest-push-unstable
+        env:
+          DOCKER_USER: ${{ secrets.DOCKER_USER }}
+          DOCKER_PASS: ${{ secrets.DOCKER_PASS }}

--- a/Makefile
+++ b/Makefile
@@ -5,21 +5,25 @@ docker-login-ci:
 
 docker-manifest-annotate:
 	echo ${VERSION}
-	${DOCKER_MANIFEST} create --amend "screego/server:unstable"     "screego/server:amd64-unstable"     "screego/server:386-unstable"     "screego/server:armv7-unstable"     "screego/server:arm64-unstable"     "screego/server:ppc64le-unstable"
 	${DOCKER_MANIFEST} create --amend "screego/server:${VERSION}" "screego/server:amd64-${VERSION}" "screego/server:386-${VERSION}" "screego/server:armv7-${VERSION}" "screego/server:arm64-${VERSION}" "screego/server:ppc64le-${VERSION}"
-	${DOCKER_MANIFEST} annotate "screego/server:unstable"     "screego/server:amd64-unstable"       --os=linux --arch=amd64
 	${DOCKER_MANIFEST} annotate "screego/server:${VERSION}" "screego/server:amd64-${VERSION}"   --os=linux --arch=amd64
-	${DOCKER_MANIFEST} annotate "screego/server:unstable"     "screego/server:386-unstable"         --os=linux --arch=386
 	${DOCKER_MANIFEST} annotate "screego/server:${VERSION}" "screego/server:386-${VERSION}"     --os=linux --arch=386
-	${DOCKER_MANIFEST} annotate "screego/server:unstable"     "screego/server:armv7-unstable"       --os=linux --arch=arm --variant=v7
 	${DOCKER_MANIFEST} annotate "screego/server:${VERSION}" "screego/server:armv7-${VERSION}"   --os=linux --arch=arm --variant=v7
-	${DOCKER_MANIFEST} annotate "screego/server:unstable"     "screego/server:arm64-unstable"       --os=linux --arch=arm64
 	${DOCKER_MANIFEST} annotate "screego/server:${VERSION}" "screego/server:arm64-${VERSION}"   --os=linux --arch=arm64
-	${DOCKER_MANIFEST} annotate "screego/server:unstable"     "screego/server:ppc64le-unstable"     --os=linux --arch=ppc64le
 	${DOCKER_MANIFEST} annotate "screego/server:${VERSION}" "screego/server:ppc64le-${VERSION}" --os=linux --arch=ppc64le
+
+docker-manifest-annotate-unstable:
+	echo ${VERSION}
+	${DOCKER_MANIFEST} create --amend "screego/server:unstable" "screego/server:amd64-unstable" "screego/server:386-unstable" "screego/server:armv7-unstable" "screego/server:arm64-unstable" "screego/server:ppc64le-unstable"
+	${DOCKER_MANIFEST} annotate "screego/server:unstable" "screego/server:amd64-unstable"   --os=linux --arch=amd64
+	${DOCKER_MANIFEST} annotate "screego/server:unstable" "screego/server:386-unstable"     --os=linux --arch=386
+	${DOCKER_MANIFEST} annotate "screego/server:unstable" "screego/server:armv7-unstable"   --os=linux --arch=arm --variant=v7
+	${DOCKER_MANIFEST} annotate "screego/server:unstable" "screego/server:arm64-unstable"   --os=linux --arch=arm64
+	${DOCKER_MANIFEST} annotate "screego/server:unstable" "screego/server:ppc64le-unstable" --os=linux --arch=ppc64le
 
 
 docker-manifest-push:
 	${DOCKER_MANIFEST} push "screego/server:${VERSION}"
-	${DOCKER_MANIFEST} push "screego/server:unstable"
 
+docker-manifest-push-unstable:
+	${DOCKER_MANIFEST} push "screego/server:unstable"


### PR DESCRIPTION
Hey! I use your Docker image and I noticed that the last time it was updated was 3 months ago, even the `unstable` tag. 

I thought it would be a good idea to push `unstable` on every commit to `master`, so that it's easier to test the current tip.

What do you think? Hope I didn't misunderstand the purpose of `unstable` tag? If I did, maybe we can push the latest master with another tag, like `latest`? 