### PR TITLE
Feature: Stream video from video devices like webcams or catpure cards

### DIFF
--- a/ui/src/Room.tsx
+++ b/ui/src/Room.tsx
@@ -20,6 +20,7 @@ import {
 } from '@material-ui/core';
 import CancelPresentationIcon from '@material-ui/icons/CancelPresentation';
 import PresentToAllIcon from '@material-ui/icons/PresentToAll';
+import VideocamIcon from '@material-ui/icons/Videocam';
 import FullScreenIcon from '@material-ui/icons/Fullscreen';
 import PeopleIcon from '@material-ui/icons/People';
 import ShowMoreIcon from '@material-ui/icons/MoreVert';
@@ -51,11 +52,13 @@ const flags = (user: RoomUser) => {
 export const Room = ({
     state,
     share,
+    shareVideoDevice,
     stopShare,
     setName,
 }: {
     state: ConnectedRoom;
     share: () => void;
+    shareVideoDevice: () => void;
     stopShare: () => void;
     setName: (name: string) => void;
 }) => {
@@ -170,6 +173,14 @@ export const Room = ({
                             </IconButton>
                         </Tooltip>
                     )}
+
+                    {!state.hostStream ? (
+                        <Tooltip title="Start Video" arrow>
+                            <IconButton onClick={shareVideoDevice}>
+                                <VideocamIcon fontSize="large" />
+                            </IconButton>
+                        </Tooltip>
+                    ) : null}
 
                     <Tooltip
                         classes={{tooltip: classes.noMaxWidth}}

--- a/ui/src/useRoom.ts
+++ b/ui/src/useRoom.ts
@@ -29,6 +29,7 @@ export interface UseRoom {
     state: RoomState;
     room: FCreateRoom;
     share: () => void;
+    shareVideoDevice: () => void;
     setName: (name: string) => void;
     stopShare: () => void;
 }
@@ -304,6 +305,25 @@ export const useRoom = (): UseRoom => {
         conn.current?.send(JSON.stringify({type: 'share', payload: {}}));
     };
 
+    const shareVideoDevice = async () => {
+        if (!navigator.mediaDevices) {
+            enqueueSnackbar(
+                'Could not start presentation. (mediaDevices undefined) Are you using https?',
+                {
+                    variant: 'error',
+                    persist: true,
+                }
+            );
+            return;
+        }
+        stream.current = await navigator.mediaDevices
+            // @ts-ignore
+            .getUserMedia({video: true});
+        setState((current) => (current ? {...current, hostStream: stream.current} : current));
+
+        conn.current?.send(JSON.stringify({type: 'share', payload: {}}));
+    }
+
     const stopShare = async () => {
         Object.values(host.current).forEach((peer) => {
             peer.close();
@@ -326,5 +346,5 @@ export const useRoom = (): UseRoom => {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
-    return {state, room, share, stopShare, setName};
+    return {state, room, share, shareVideoDevice, stopShare, setName};
 };

--- a/ui/src/useRoom.ts
+++ b/ui/src/useRoom.ts
@@ -322,7 +322,7 @@ export const useRoom = (): UseRoom => {
         setState((current) => (current ? {...current, hostStream: stream.current} : current));
 
         conn.current?.send(JSON.stringify({type: 'share', payload: {}}));
-    }
+    };
 
     const stopShare = async () => {
         Object.values(host.current).forEach((peer) => {


### PR DESCRIPTION
My team and I are using screego for our daily remote pair programming and it would be absolutely great if we can also stream from other video devices.
For example a web cam or a HDMI screen capture device.

I've implemented a very basic version of this feature.
I already understand that you are trying to keep screego pretty basic and I can image that this feature could be to much for the scope of this project.
So I'm really interested in your opinion about this feature. 