### PR TITLE
feat: add configurable default value for room closing policy in room creation dialog

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -57,6 +57,8 @@ type Config struct {
 	CheckOrigin  func(string) bool `ignored:"true" json:"-"`
 	ExternalIPV4 net.IP            `ignored:"true"`
 	ExternalIPV6 net.IP            `ignored:"true"`
+
+	CloseRoomWhenOwnerLeaves bool `default:"true" split_words:"true"`
 }
 
 func (c Config) parsePortRange() (uint16, uint16, error) {

--- a/router/router.go
+++ b/router/router.go
@@ -17,10 +17,11 @@ import (
 )
 
 type UIConfig struct {
-	AuthMode string `json:"authMode"`
-	User     string `json:"user"`
-	LoggedIn bool   `json:"loggedIn"`
-	Version  string `json:"version"`
+	AuthMode                 string `json:"authMode"`
+	User                     string `json:"user"`
+	LoggedIn                 bool   `json:"loggedIn"`
+	Version                  string `json:"version"`
+	CloseRoomWhenOwnerLeaves bool   `json:"closeRoomWhenOwnerLeaves"`
 }
 
 func Router(conf config.Config, rooms *ws.Rooms, users *auth.Users, version string) *mux.Router {
@@ -37,10 +38,11 @@ func Router(conf config.Config, rooms *ws.Rooms, users *auth.Users, version stri
 	router.Methods("GET").Path("/config").HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		user, loggedIn := users.CurrentUser(r)
 		_ = json.NewEncoder(w).Encode(&UIConfig{
-			AuthMode: conf.AuthMode,
-			LoggedIn: loggedIn,
-			User:     user,
-			Version:  version,
+			AuthMode:                 conf.AuthMode,
+			LoggedIn:                 loggedIn,
+			User:                     user,
+			Version:                  version,
+			CloseRoomWhenOwnerLeaves: conf.CloseRoomWhenOwnerLeaves,
 		})
 	})
 	if conf.Prometheus {

--- a/screego.config.example
+++ b/screego.config.example
@@ -67,6 +67,10 @@ SCREEGO_CORS_ALLOWED_ORIGINS=
 #   screego hash --name "user1" --pass "your password"
 SCREEGO_USERS_FILE=
 
+# Defines the default value for the checkbox in the room creation dialog to select
+# if the room should be closed when the room owner leaves
+SCREEGO_CLOSE_ROOM_WHEN_OWNER_LEAVES=true
+
 # The loglevel (one of: debug, info, warn, error)
 SCREEGO_LOG_LEVEL=info
 

--- a/ui/src/RoomManage.tsx
+++ b/ui/src/RoomManage.tsx
@@ -43,7 +43,7 @@ const CreateRoom = ({room, config}: Pick<UseRoom, 'room'> & {config: UIConfig}) 
         () => getRoomFromURL(window.location.search) ?? randomRoomName()
     );
     const [mode, setMode] = React.useState<RoomMode>(defaultMode(config.authMode, config.loggedIn));
-    const [ownerLeave, setOwnerLeave] = React.useState(true);
+    const [ownerLeave, setOwnerLeave] = React.useState(config.closeRoomWhenOwnerLeaves);
     const submit = () =>
         room({
             type: 'create',

--- a/ui/src/message.ts
+++ b/ui/src/message.ts
@@ -10,6 +10,7 @@ export interface UIConfig {
     user: string;
     loggedIn: boolean;
     version: string;
+    closeRoomWhenOwnerLeaves: boolean;
 }
 
 export interface RoomConfiguration {

--- a/ui/src/useConfig.ts
+++ b/ui/src/useConfig.ts
@@ -17,6 +17,7 @@ export const useConfig = (): UseConfig => {
         loggedIn: false,
         loading: true,
         version: 'unknown',
+        closeRoomWhenOwnerLeaves: true,
     });
 
     const refetch = React.useCallback(async () => {


### PR DESCRIPTION
This PR adds a new configuration option to set the default value for the checkbox in the room creation dialog that determines whether the room should be closed after the owner leaves.

The original default value has been retained.

closes #73 