### PR TITLE
Support external TURN server

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -44,11 +44,13 @@ type Config struct {
 	ServerAddress string `default:":5050" split_words:"true"`
 	Secret        []byte `split_words:"true"`
 
-	TurnAddress        string `default:":3478" required:"true" split_words:"true"`
-	TurnStrictAuth     bool   `default:"true" split_words:"true"`
-	TurnPortRange      string `split_words:"true"`
-	TurnExternal       bool   `default:"false" split_words:"true"`
-	TurnExternalSecret string `split_words:"true"`
+	TurnAddress    string `default:":3478" required:"true" split_words:"true"`
+	TurnStrictAuth bool   `default:"true" split_words:"true"`
+	TurnPortRange  string `split_words:"true"`
+
+	TurnExternalIP     []string `split_words:"true"`
+	TurnExternalPort   string   `default:"3478" split_words:"true"`
+	TurnExternalSecret string   `split_words:"true"`
 
 	TrustProxyHeaders  bool     `split_words:"true"`
 	AuthMode           string   `default:"turn" split_words:"true"`
@@ -59,6 +61,9 @@ type Config struct {
 	CheckOrigin  func(string) bool `ignored:"true" json:"-"`
 	ExternalIPV4 net.IP            `ignored:"true"`
 	ExternalIPV6 net.IP            `ignored:"true"`
+
+	TurnExternalIPV4 net.IP `ignored:"true"`
+	TurnExternalIPV6 net.IP `ignored:"true"`
 
 	CloseRoomWhenOwnerLeaves bool `default:"true" split_words:"true"`
 }
@@ -140,12 +145,6 @@ func Get() (Config, []FutureLog) {
 		}
 	}
 
-	if config.TurnExternal {
-		if config.TurnExternalSecret == "" {
-			logs = append(logs, futureFatal("SCREEGO_TURN_EXTERNAL_SECRET must be set if external TURN server is used"))
-		}
-	}
-
 	var compiledAllowedOrigins []*regexp.Regexp
 	for _, origin := range config.CorsAllowedOrigins {
 		compiled, err := regexp.Compile(origin)
@@ -179,8 +178,23 @@ func Get() (Config, []FutureLog) {
 	}
 
 	var errs []FutureLog
-	config.ExternalIPV4, config.ExternalIPV6, errs = validateExternalIP(config.ExternalIP)
+	config.ExternalIPV4, config.ExternalIPV6, errs = validateExternalIP(config.ExternalIP, "SCREEGO_EXTERNAL_IP")
 	logs = append(logs, errs...)
+
+	config.TurnExternalIPV4, config.TurnExternalIPV6, errs = validateExternalIP(config.TurnExternalIP, "SCREEGO_TURN_EXTERNAL_IP")
+	logs = append(logs, errs...)
+
+	if config.ExternalIPV4 == nil && config.ExternalIPV6 == nil && config.TurnExternalIPV4 == nil && config.TurnExternalIPV6 == nil {
+		logs = append(logs, futureFatal("SCREEGO_EXTERNAL_IP or SCREEGO_TURN_EXTERNAL_IP must be set"))
+	}
+
+	if (config.ExternalIPV4 != nil || config.ExternalIPV6 != nil) && (config.TurnExternalIPV4 != nil || config.TurnExternalIPV6 != nil) {
+		logs = append(logs, futureFatal("SCREEGO_EXTERNAL_IP and SCREEGO_TURN_EXTERNAL_IP must not be both set"))
+	}
+
+	if (config.TurnExternalIPV4 != nil || config.TurnExternalIPV6 != nil) && config.TurnExternalSecret == "" {
+		logs = append(logs, futureFatal("SCREEGO_TURN_EXTERNAL_SECRET must be set if external TURN server is used"))
+	}
 
 	min, max, err := config.parsePortRange()
 	if err != nil {
@@ -200,16 +214,16 @@ func Get() (Config, []FutureLog) {
 	return config, logs
 }
 
-func validateExternalIP(ips []string) (net.IP, net.IP, []FutureLog) {
+func validateExternalIP(ips []string, config string) (net.IP, net.IP, []FutureLog) {
 	if len(ips) == 0 {
-		return nil, nil, []FutureLog{futureFatal("SCREEGO_EXTERNAL_IP must be set")}
+		return nil, nil, nil
 	}
 
 	first := ips[0]
 
 	firstParsed := net.ParseIP(first)
 	if firstParsed == nil || first == "0.0.0.0" {
-		return nil, nil, []FutureLog{futureFatal(fmt.Sprintf("invalid SCREEGO_EXTERNAL_IP: %s", first))}
+		return nil, nil, []FutureLog{futureFatal(fmt.Sprintf("invalid %s: %s", config, first))}
 	}
 	firstIsIP4 := firstParsed.To4() != nil
 
@@ -224,17 +238,17 @@ func validateExternalIP(ips []string) (net.IP, net.IP, []FutureLog) {
 
 	secondParsed := net.ParseIP(second)
 	if secondParsed == nil || second == "0.0.0.0" {
-		return nil, nil, []FutureLog{futureFatal(fmt.Sprintf("invalid SCREEGO_EXTERNAL_IP: %s", second))}
+		return nil, nil, []FutureLog{futureFatal(fmt.Sprintf("invalid %s: %s", config, second))}
 	}
 
 	secondIsIP4 := secondParsed.To4() != nil
 
 	if firstIsIP4 == secondIsIP4 {
-		return nil, nil, []FutureLog{futureFatal("invalid SCREEGO_EXTERNAL_IP: the ips must be of different type ipv4/ipv6")}
+		return nil, nil, []FutureLog{futureFatal(fmt.Sprintf("invalid %s: the ips must be of different type ipv4/ipv6", config))}
 	}
 
 	if len(ips) > 2 {
-		return nil, nil, []FutureLog{futureFatal("invalid SCREEGO_EXTERNAL_IP: too many ips supplied")}
+		return nil, nil, []FutureLog{futureFatal(fmt.Sprintf("invalid %s: too many ips supplied", config))}
 	}
 
 	if !firstIsIP4 {

--- a/config/config.go
+++ b/config/config.go
@@ -44,9 +44,11 @@ type Config struct {
 	ServerAddress string `default:":5050" split_words:"true"`
 	Secret        []byte `split_words:"true"`
 
-	TurnAddress    string `default:":3478" required:"true" split_words:"true"`
-	TurnStrictAuth bool   `default:"true" split_words:"true"`
-	TurnPortRange  string `split_words:"true"`
+	TurnAddress        string `default:":3478" required:"true" split_words:"true"`
+	TurnStrictAuth     bool   `default:"true" split_words:"true"`
+	TurnPortRange      string `split_words:"true"`
+	TurnExternal       bool   `default:"false" split_words:"true"`
+	TurnExternalSecret string `split_words:"true"`
 
 	TrustProxyHeaders  bool     `split_words:"true"`
 	AuthMode           string   `default:"turn" split_words:"true"`
@@ -135,6 +137,12 @@ func Get() (Config, []FutureLog) {
 
 		if config.TLSKeyFile == "" {
 			logs = append(logs, futureFatal("SCREEGO_TLS_KEY_FILE must be set if TLS is enabled"))
+		}
+	}
+
+	if config.TurnExternal {
+		if config.TurnExternalSecret == "" {
+			logs = append(logs, futureFatal("SCREEGO_TURN_EXTERNAL_SECRET must be set if external TURN server is used"))
 		}
 	}
 

--- a/screego.config.example
+++ b/screego.config.example
@@ -1,4 +1,5 @@
-# The external ip of the server.
+# The external ip of the TURN server (which is where screego is hosted,
+# unless you use external TURN server).
 # When using a dual stack setup define both IPv4 & IPv6 separated by a comma.
 # Execute the following command on the server you want to host Screego
 # to find your external ip.
@@ -35,6 +36,13 @@ SCREEGO_TURN_PORT_RANGE=
 # match. Disable this feature, if you use some kind of proxy which changes the
 # remote ip.
 SCREEGO_TURN_STRICT_AUTH=true
+
+# If true, screego will not start TURN server and instead use an external one
+# hosted on the address you specify via SCREEGO_EXTERNAL_IP.
+SCREEGO_TURN_EXTERNAL=false
+
+# Authentication secret for the external TURN server.
+SCREEGO_TURN_EXTERNAL_SECRET=
 
 # If reverse proxy headers should be trusted.
 # Screego uses ip whitelisting for authentication

--- a/screego.config.example
+++ b/screego.config.example
@@ -36,9 +36,9 @@ SCREEGO_TURN_PORT_RANGE=
 # remote ip.
 SCREEGO_TURN_STRICT_AUTH=true
 
-# If set, screego will not start TURN server and instead use a external TURN server.
+# If set, screego will not start TURN server and instead use an external TURN server.
 # When using a dual stack setup define both IPv4 & IPv6 separated by a comma.
-# Execute the following command on the server you host TURN server
+# Execute the following command on the server where you host TURN server
 # to find your external ip.
 #   curl 'https://api.ipify.org'
 # Example:

--- a/screego.config.example
+++ b/screego.config.example
@@ -1,5 +1,4 @@
-# The external ip of the TURN server (which is where screego is hosted,
-# unless you use external TURN server).
+# The external ip of the TURN server.
 # When using a dual stack setup define both IPv4 & IPv6 separated by a comma.
 # Execute the following command on the server you want to host Screego
 # to find your external ip.
@@ -37,9 +36,17 @@ SCREEGO_TURN_PORT_RANGE=
 # remote ip.
 SCREEGO_TURN_STRICT_AUTH=true
 
-# If true, screego will not start TURN server and instead use an external one
-# hosted on the address you specify via SCREEGO_EXTERNAL_IP.
-SCREEGO_TURN_EXTERNAL=false
+# If set, screego will not start TURN server and instead use a external TURN server.
+# When using a dual stack setup define both IPv4 & IPv6 separated by a comma.
+# Execute the following command on the server you host TURN server
+# to find your external ip.
+#   curl 'https://api.ipify.org'
+# Example:
+#   192.168.178.2,2a01:c22:a87c:e500:2d8:61ff:fec7:f92a
+SCREEGO_TURN_EXTERNAL_IP=
+
+# The port the external TURN server listens on.
+SCREEGO_TURN_EXTERNAL_PORT=3478
 
 # Authentication secret for the external TURN server.
 SCREEGO_TURN_EXTERNAL_SECRET=

--- a/screego.config.example
+++ b/screego.config.example
@@ -1,4 +1,4 @@
-# The external ip of the TURN server.
+# The external ip of the server.
 # When using a dual stack setup define both IPv4 & IPv6 separated by a comma.
 # Execute the following command on the server you want to host Screego
 # to find your external ip.

--- a/turn/server.go
+++ b/turn/server.go
@@ -25,8 +25,8 @@ type Server interface {
 }
 
 type InternalServer struct {
-	ipV4       net.IP
-	ipV6       net.IP
+	ipv4       net.IP
+	ipv6       net.IP
 	port       string
 	lock       sync.RWMutex
 	strictAuth bool
@@ -34,8 +34,8 @@ type InternalServer struct {
 }
 
 type ExternalServer struct {
-	ipV4   net.IP
-	ipV6   net.IP
+	ipv4   net.IP
+	ipv6   net.IP
 	port   string
 	secret []byte
 	ttl    time.Duration
@@ -49,8 +49,8 @@ type Entry struct {
 const Realm = "screego"
 
 type Generator struct {
-	ipV4 net.IP
-	ipV6 net.IP
+	ipv4 net.IP
+	ipv6 net.IP
 	turn.RelayAddressGenerator
 }
 
@@ -60,10 +60,10 @@ func (r *Generator) AllocatePacketConn(network string, requestedPort int) (net.P
 		return conn, addr, err
 	}
 	relayAddr := *addr.(*net.UDPAddr)
-	if r.ipV6 == nil || (relayAddr.IP.To4() != nil && r.ipV4 != nil) {
-		relayAddr.IP = r.ipV4
+	if r.ipv6 == nil || (relayAddr.IP.To4() != nil && r.ipv4 != nil) {
+		relayAddr.IP = r.ipv4
 	} else {
-		relayAddr.IP = r.ipV6
+		relayAddr.IP = r.ipv6
 	}
 	if err == nil {
 		log.Debug().Str("addr", addr.String()).Str("relayaddr", relayAddr.String()).Msg("TURN allocated")
@@ -81,8 +81,8 @@ func Start(conf config.Config) (Server, error) {
 
 func newExternalServer(conf config.Config) (Server, error) {
 	return &ExternalServer{
-		ipV4:   conf.TurnExternalIPV4,
-		ipV6:   conf.TurnExternalIPV6,
+		ipv4:   conf.TurnExternalIPV4,
+		ipv6:   conf.TurnExternalIPV6,
 		port:   conf.TurnExternalPort,
 		secret: []byte(conf.TurnExternalSecret),
 		ttl:    24 * time.Hour,
@@ -101,16 +101,16 @@ func newInternalServer(conf config.Config) (Server, error) {
 
 	split := strings.Split(conf.TurnAddress, ":")
 	svr := &InternalServer{
-		ipV4:       conf.ExternalIPV4,
-		ipV6:       conf.ExternalIPV6,
+		ipv4:       conf.ExternalIPV4,
+		ipv6:       conf.ExternalIPV6,
 		port:       split[len(split)-1],
 		lookup:     map[string]Entry{},
 		strictAuth: conf.TurnStrictAuth,
 	}
 
 	gen := &Generator{
-		ipV4:                  conf.ExternalIPV4,
-		ipV6:                  conf.ExternalIPV6,
+		ipv4:                  conf.ExternalIPV4,
+		ipv6:                  conf.ExternalIPV6,
 		RelayAddressGenerator: generator(conf),
 	}
 
@@ -208,19 +208,19 @@ func (a *ExternalServer) Credentials(id string, addr net.IP) (string, string) {
 }
 
 func (a *InternalServer) IPV4() net.IP {
-	return a.ipV4
+	return a.ipv4
 }
 
 func (a *ExternalServer) IPV4() net.IP {
-	return a.ipV4
+	return a.ipv4
 }
 
 func (a *InternalServer) IPV6() net.IP {
-	return a.ipV6
+	return a.ipv6
 }
 
 func (a *ExternalServer) IPV6() net.IP {
-	return a.ipV6
+	return a.ipv6
 }
 
 func (a *InternalServer) Port() string {

--- a/turn/server.go
+++ b/turn/server.go
@@ -124,7 +124,7 @@ func generator(conf config.Config) turn.RelayAddressGenerator {
 	return &RelayAddressGeneratorNone{}
 }
 
-func (a *InternalServer) Allow(username, password string, addr net.IP) {
+func (a *InternalServer) allow(username, password string, addr net.IP) {
 	a.lock.Lock()
 	defer a.lock.Unlock()
 	a.lookup[username] = Entry{
@@ -178,7 +178,7 @@ func (a *InternalServer) authenticate(username, realm string, addr net.Addr) ([]
 
 func (a *InternalServer) Credentials(id string, addr net.IP) (string, string) {
 	password := util.RandString(20)
-	a.Allow(id, password, addr)
+	a.allow(id, password, addr)
 	return id, password
 }
 

--- a/ws/room.go
+++ b/ws/room.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/rs/xid"
 	"github.com/screego/server/config"
-	"github.com/screego/server/util"
 	"github.com/screego/server/ws/outgoing"
 )
 
@@ -48,11 +47,9 @@ func (r *Room) newSession(host, client xid.ID, rooms *Rooms) {
 		iceHost = []outgoing.ICEServer{{URLs: rooms.addresses("stun", false)}}
 		iceClient = []outgoing.ICEServer{{URLs: rooms.addresses("stun", false)}}
 	case ConnectionTURN:
-		hostPW := util.RandString(20)
-		clientPW := util.RandString(20)
-		hostName := id.String() + "host"
+		hostName, hostPW := rooms.turnServer.Credentials(id.String() + "host")
 		rooms.turnServer.Allow(hostName, hostPW, r.Users[host].Addr)
-		clientName := id.String() + "client"
+		clientName, clientPW := rooms.turnServer.Credentials(id.String() + "client")
 		rooms.turnServer.Allow(clientName, clientPW, r.Users[client].Addr)
 		iceHost = []outgoing.ICEServer{{
 			URLs:       rooms.addresses("turn", true),
@@ -72,15 +69,15 @@ func (r *Room) newSession(host, client xid.ID, rooms *Rooms) {
 
 func (r *Rooms) addresses(prefix string, tcp bool) (result []string) {
 	if r.config.ExternalIPV4 != nil {
-		result = append(result, fmt.Sprintf("%s:%s:%s", prefix, r.config.ExternalIPV4.String(), r.turnServer.Port))
+		result = append(result, fmt.Sprintf("%s:%s:%s", prefix, r.config.ExternalIPV4.String(), r.turnServer.Port()))
 		if tcp {
-			result = append(result, fmt.Sprintf("%s:%s:%s?transport=tcp", prefix, r.config.ExternalIPV4.String(), r.turnServer.Port))
+			result = append(result, fmt.Sprintf("%s:%s:%s?transport=tcp", prefix, r.config.ExternalIPV4.String(), r.turnServer.Port()))
 		}
 	}
 	if r.config.ExternalIPV6 != nil {
-		result = append(result, fmt.Sprintf("%s:[%s]:%s", prefix, r.config.ExternalIPV6.String(), r.turnServer.Port))
+		result = append(result, fmt.Sprintf("%s:[%s]:%s", prefix, r.config.ExternalIPV6.String(), r.turnServer.Port()))
 		if tcp {
-			result = append(result, fmt.Sprintf("%s:[%s]:%s?transport=tcp", prefix, r.config.ExternalIPV6.String(), r.turnServer.Port))
+			result = append(result, fmt.Sprintf("%s:[%s]:%s?transport=tcp", prefix, r.config.ExternalIPV6.String(), r.turnServer.Port()))
 		}
 	}
 	return

--- a/ws/room.go
+++ b/ws/room.go
@@ -66,16 +66,16 @@ func (r *Room) newSession(host, client xid.ID, rooms *Rooms) {
 }
 
 func (r *Rooms) addresses(prefix string, tcp bool) (result []string) {
-	if r.turnServer.IPV4() != nil {
-		result = append(result, fmt.Sprintf("%s:%s:%s", prefix, r.turnServer.IPV4().String(), r.turnServer.Port()))
+	if r.config.TurnIPV4 != nil {
+		result = append(result, fmt.Sprintf("%s:%s:%s", prefix, r.config.TurnIPV4.String(), r.config.TurnPort))
 		if tcp {
-			result = append(result, fmt.Sprintf("%s:%s:%s?transport=tcp", prefix, r.turnServer.IPV4().String(), r.turnServer.Port()))
+			result = append(result, fmt.Sprintf("%s:%s:%s?transport=tcp", prefix, r.config.TurnIPV4.String(), r.config.TurnPort))
 		}
 	}
-	if r.turnServer.IPV6() != nil {
-		result = append(result, fmt.Sprintf("%s:[%s]:%s", prefix, r.turnServer.IPV6().String(), r.turnServer.Port()))
+	if r.config.TurnIPV6 != nil {
+		result = append(result, fmt.Sprintf("%s:[%s]:%s", prefix, r.config.TurnIPV6.String(), r.config.TurnPort))
 		if tcp {
-			result = append(result, fmt.Sprintf("%s:[%s]:%s?transport=tcp", prefix, r.turnServer.IPV6().String(), r.turnServer.Port()))
+			result = append(result, fmt.Sprintf("%s:[%s]:%s?transport=tcp", prefix, r.config.TurnIPV6.String(), r.config.TurnPort))
 		}
 	}
 	return

--- a/ws/room.go
+++ b/ws/room.go
@@ -66,16 +66,16 @@ func (r *Room) newSession(host, client xid.ID, rooms *Rooms) {
 }
 
 func (r *Rooms) addresses(prefix string, tcp bool) (result []string) {
-	if r.config.ExternalIPV4 != nil {
-		result = append(result, fmt.Sprintf("%s:%s:%s", prefix, r.config.ExternalIPV4.String(), r.turnServer.Port()))
+	if r.turnServer.IPV4() != nil {
+		result = append(result, fmt.Sprintf("%s:%s:%s", prefix, r.turnServer.IPV4().String(), r.turnServer.Port()))
 		if tcp {
-			result = append(result, fmt.Sprintf("%s:%s:%s?transport=tcp", prefix, r.config.ExternalIPV4.String(), r.turnServer.Port()))
+			result = append(result, fmt.Sprintf("%s:%s:%s?transport=tcp", prefix, r.turnServer.IPV4().String(), r.turnServer.Port()))
 		}
 	}
-	if r.config.ExternalIPV6 != nil {
-		result = append(result, fmt.Sprintf("%s:[%s]:%s", prefix, r.config.ExternalIPV6.String(), r.turnServer.Port()))
+	if r.turnServer.IPV6() != nil {
+		result = append(result, fmt.Sprintf("%s:[%s]:%s", prefix, r.turnServer.IPV6().String(), r.turnServer.Port()))
 		if tcp {
-			result = append(result, fmt.Sprintf("%s:[%s]:%s?transport=tcp", prefix, r.config.ExternalIPV6.String(), r.turnServer.Port()))
+			result = append(result, fmt.Sprintf("%s:[%s]:%s?transport=tcp", prefix, r.turnServer.IPV6().String(), r.turnServer.Port()))
 		}
 	}
 	return

--- a/ws/room.go
+++ b/ws/room.go
@@ -47,10 +47,8 @@ func (r *Room) newSession(host, client xid.ID, rooms *Rooms) {
 		iceHost = []outgoing.ICEServer{{URLs: rooms.addresses("stun", false)}}
 		iceClient = []outgoing.ICEServer{{URLs: rooms.addresses("stun", false)}}
 	case ConnectionTURN:
-		hostName, hostPW := rooms.turnServer.Credentials(id.String() + "host")
-		rooms.turnServer.Allow(hostName, hostPW, r.Users[host].Addr)
-		clientName, clientPW := rooms.turnServer.Credentials(id.String() + "client")
-		rooms.turnServer.Allow(clientName, clientPW, r.Users[client].Addr)
+		hostName, hostPW := rooms.turnServer.Credentials(id.String()+"host", r.Users[host].Addr)
+		clientName, clientPW := rooms.turnServer.Credentials(id.String()+"client", r.Users[client].Addr)
 		iceHost = []outgoing.ICEServer{{
 			URLs:       rooms.addresses("turn", true),
 			Credential: hostPW,

--- a/ws/rooms.go
+++ b/ws/rooms.go
@@ -13,7 +13,7 @@ import (
 	"github.com/screego/server/turn"
 )
 
-func NewRooms(tServer *turn.Server, users *auth.Users, conf config.Config) *Rooms {
+func NewRooms(tServer turn.Server, users *auth.Users, conf config.Config) *Rooms {
 	return &Rooms{
 		Rooms:      map[string]*Room{},
 		Incoming:   make(chan ClientMessage),
@@ -39,7 +39,7 @@ func NewRooms(tServer *turn.Server, users *auth.Users, conf config.Config) *Room
 }
 
 type Rooms struct {
-	turnServer *turn.Server
+	turnServer turn.Server
 	Rooms      map[string]*Room
 	Incoming   chan ClientMessage
 	upgrader   websocket.Upgrader


### PR DESCRIPTION
This is a follow-up on @athoune's work in #63 although I ended up almost rewriting it from scratch to learn how it all works 🙂 

I tried to keep the patch short, maybe easier to review and easier to maintain afterwards. We might want to refactor this later if someone asks to support other authentication mechanisms against external TURN servers other than http://tools.ietf.org/html/draft-uberti-behave-turn-rest-00, lets see if that ever happens, and until then I thought to keep it simple.

I tested with coturn and using `forceTurn=true` and all seems to work very well 🙂 

Fixes #48
Closes #63