### PR TITLE
Show NAT traversal mode as a label

### DIFF
--- a/ui/src/RoomManage.tsx
+++ b/ui/src/RoomManage.tsx
@@ -69,20 +69,12 @@ const CreateRoom = ({room, config}: Pick<UseRoom, 'room'> & {config: UIConfig}) 
                     }
                     label="Close Room after you leave"
                 />
-                <TextField
-                    fullWidth
-                    label="NAT Traversal via"
-                    value={mode.toUpperCase()}
-                    margin="dense"
-                    InputProps={{
-                        readOnly: true,
-                        endAdornment: (
-                            <IconButton size="small" href="https://screego.net/#/nat-traversal">
-                                <HelpIcon />
-                            </IconButton>
-                        ),
-                    }}
-                />
+                <Typography style={{display: 'flex', justifyContent: 'space-between'}}>
+                    <span>Nat Traversal via: {mode.toUpperCase()}</span>
+                    <IconButton size="small" href="https://screego.net/#/nat-traversal">
+                        <HelpIcon />
+                    </IconButton>
+                </Typography>
                 <Button onClick={submit} fullWidth variant="contained">
                     Create Room
                 </Button>

--- a/ui/src/RoomManage.tsx
+++ b/ui/src/RoomManage.tsx
@@ -5,7 +5,6 @@ import {
     FormControl,
     FormControlLabel,
     Grid,
-    IconButton,
     Paper,
     TextField,
     Typography,
@@ -15,7 +14,6 @@ import {FCreateRoom, UseRoom} from './useRoom';
 import {RoomMode, UIConfig} from './message';
 import {randomRoomName} from './name';
 import {getRoomFromURL} from './useRoomID';
-import HelpIcon from '@material-ui/icons/Help';
 import logo from './logo.svg';
 import {UseConfig} from './useConfig';
 import {LoginForm} from './LoginForm';

--- a/ui/src/RoomManage.tsx
+++ b/ui/src/RoomManage.tsx
@@ -6,10 +6,7 @@ import {
     FormControlLabel,
     Grid,
     IconButton,
-    InputLabel,
-    MenuItem,
     Paper,
-    Select,
     TextField,
     Typography,
     Link,
@@ -42,7 +39,7 @@ const CreateRoom = ({room, config}: Pick<UseRoom, 'room'> & {config: UIConfig}) 
     const [id, setId] = React.useState(
         () => getRoomFromURL(window.location.search) ?? randomRoomName()
     );
-    const [mode, setMode] = React.useState<RoomMode>(defaultMode(config.authMode, config.loggedIn));
+    const [mode] = React.useState<RoomMode>(defaultMode(config.authMode, config.loggedIn));
     const [ownerLeave, setOwnerLeave] = React.useState(config.closeRoomWhenOwnerLeaves);
     const submit = () =>
         room({
@@ -72,29 +69,20 @@ const CreateRoom = ({room, config}: Pick<UseRoom, 'room'> & {config: UIConfig}) 
                     }
                     label="Close Room after you leave"
                 />
-                <FormControl margin="dense">
-                    <InputLabel>NAT Traversal via</InputLabel>
-                    <Select
-                        fullWidth
-                        value={mode}
-                        onChange={(x) => setMode(x.target.value as RoomMode)}
-                        endAdornment={
+                <TextField
+                    fullWidth
+                    label="NAT Traversal via"
+                    value={mode.toUpperCase()}
+                    margin="dense"
+                    InputProps={{
+                        readOnly: true,
+                        endAdornment: (
                             <IconButton size="small" href="https://screego.net/#/nat-traversal">
                                 <HelpIcon />
                             </IconButton>
-                        }>
-                        <MenuItem
-                            value={RoomMode.Stun}
-                            disabled={config.authMode === 'all' && !config.loggedIn}>
-                            STUN
-                        </MenuItem>
-                        <MenuItem
-                            value={RoomMode.Turn}
-                            disabled={config.authMode !== 'none' && !config.loggedIn}>
-                            TURN
-                        </MenuItem>
-                    </Select>
-                </FormControl>
+                        ),
+                    }}
+                />
                 <Button onClick={submit} fullWidth variant="contained">
                     Create Room
                 </Button>

--- a/ui/src/RoomManage.tsx
+++ b/ui/src/RoomManage.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import {
+    Box,
     Button,
     Checkbox,
     FormControl,
@@ -67,15 +68,17 @@ const CreateRoom = ({room, config}: Pick<UseRoom, 'room'> & {config: UIConfig}) 
                     }
                     label="Close Room after you leave"
                 />
-                <Typography>
-                    Nat Traversal via:{' '}
-                    <Link
-                        href="https://screego.net/#/nat-traversal"
-                        target="_blank"
-                        rel="noreferrer">
-                        {mode.toUpperCase()}
-                    </Link>
-                </Typography>
+                <Box paddingBottom={2}>
+                    <Typography>
+                        Nat Traversal via:{' '}
+                        <Link
+                            href="https://screego.net/#/nat-traversal"
+                            target="_blank"
+                            rel="noreferrer">
+                            {mode.toUpperCase()}
+                        </Link>
+                    </Typography>
+                </Box>
                 <Button onClick={submit} fullWidth variant="contained">
                     Create Room
                 </Button>

--- a/ui/src/RoomManage.tsx
+++ b/ui/src/RoomManage.tsx
@@ -39,7 +39,7 @@ const CreateRoom = ({room, config}: Pick<UseRoom, 'room'> & {config: UIConfig}) 
     const [id, setId] = React.useState(
         () => getRoomFromURL(window.location.search) ?? randomRoomName()
     );
-    const [mode] = React.useState<RoomMode>(defaultMode(config.authMode, config.loggedIn));
+    const mode = defaultMode(config.authMode, config.loggedIn);
     const [ownerLeave, setOwnerLeave] = React.useState(config.closeRoomWhenOwnerLeaves);
     const submit = () =>
         room({

--- a/ui/src/RoomManage.tsx
+++ b/ui/src/RoomManage.tsx
@@ -68,7 +68,7 @@ const CreateRoom = ({room, config}: Pick<UseRoom, 'room'> & {config: UIConfig}) 
                     }
                     label="Close Room after you leave"
                 />
-                <Box paddingBottom={2}>
+                <Box paddingBottom={0.5}>
                     <Typography>
                         Nat Traversal via:{' '}
                         <Link

--- a/ui/src/RoomManage.tsx
+++ b/ui/src/RoomManage.tsx
@@ -69,11 +69,14 @@ const CreateRoom = ({room, config}: Pick<UseRoom, 'room'> & {config: UIConfig}) 
                     }
                     label="Close Room after you leave"
                 />
-                <Typography style={{display: 'flex', justifyContent: 'space-between'}}>
-                    <span>Nat Traversal via: {mode.toUpperCase()}</span>
-                    <IconButton size="small" href="https://screego.net/#/nat-traversal">
-                        <HelpIcon />
-                    </IconButton>
+                <Typography>
+                    Nat Traversal via:{' '}
+                    <Link
+                        href="https://screego.net/#/nat-traversal"
+                        target="_blank"
+                        rel="noreferrer">
+                        {mode.toUpperCase()}
+                    </Link>
                 </Typography>
                 <Button onClick={submit} fullWidth variant="contained">
                     Create Room


### PR DESCRIPTION
A quick idea to address #62, not sure if you will be fully satisfied to close that, but I thought this could be at the very least a temporary improvement? It looks pretty similar to the current UI, but is simply not clickable anymore, it's all I even wanted 😄 

| when | on load | on click | 
| - | - | - |
| Before | ![image](https://user-images.githubusercontent.com/1177900/119280162-570f3a80-bc30-11eb-9b9b-e662c871b0b1.png) | ![image](https://user-images.githubusercontent.com/1177900/119280183-71491880-bc30-11eb-8cb1-4edc7a72ae10.png) |
 | After | ![image](https://user-images.githubusercontent.com/1177900/119280213-95a4f500-bc30-11eb-9eff-c7437f3b5f1d.png) | ![image](https://user-images.githubusercontent.com/1177900/119280224-a48ba780-bc30-11eb-9554-9ba790c8bf0d.png) |

Fixes #62 