### PR TITLE
feat: align video to vertical and horizontal center

### DIFF
--- a/ui/src/Room.tsx
+++ b/ui/src/Room.tsx
@@ -548,5 +548,9 @@ const useStyles = makeStyles((theme: Theme) => ({
         height: '100%',
 
         overflow: 'auto',
+
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
     },
 }));


### PR DESCRIPTION
This adds small CSS to align the video to the vertical and horizontal center of videoContainer instead of positioning the video in the upper left corner.

As I cannot build the server, this is untested from my side. I have tested the CSS on a screego instance in a browser and got no issues.

Fixes #109