### PR TITLE
Add nonroot user to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM scratch
+USER 1001
 COPY screego /screego
 EXPOSE 3478/tcp
 EXPOSE 3478/udp


### PR DESCRIPTION
Running containers as a privileged user weakens their runtime security, allowing any user whose code runs on the container to perform administrative actions.
In Linux containers, the privileged user is usually named root.