### PR TITLE
Support audio

### DIFF
--- a/ui/src/Room.tsx
+++ b/ui/src/Room.tsx
@@ -133,6 +133,7 @@ export const Room = ({
         [setHoverControl]
     );
 
+    const audioDisabled = !audioStream || selectedStream === HostStream;
     const controlVisible = showControl || open || hoverControl;
 
     useHotkeys('s', () => (state.hostStream ? stopShare() : share()), [state.hostStream]);
@@ -300,10 +301,10 @@ export const Room = ({
                     <Tooltip title={playingAudio ? "Mute Audio" : "Hear Audio"} arrow>
                         <IconButton
                             onClick={toggleAudio}
-                            disabled={!audioStream || selectedStream === HostStream}
+                            disabled={audioDisabled}
                             size="large"
                         >
-                            {playingAudio ? <HeadsetIcon fontSize="large" /> : <HeadsetOff fontSize="large" />}
+                            {playingAudio && !audioDisabled ? <HeadsetIcon fontSize="large" /> : <HeadsetOff fontSize="large" />}
                         </IconButton>
                     </Tooltip>
                     <Tooltip title="Fullscreen" arrow>

--- a/ui/src/useRoom.ts
+++ b/ui/src/useRoom.ts
@@ -25,7 +25,8 @@ export type ConnectedRoom = {
 interface ClientStream {
     id: string;
     peer_id: string;
-    stream: MediaStream;
+    videoStream?: MediaStream;
+    audioStream?: MediaStream;
 }
 
 export interface UseRoom {
@@ -121,7 +122,7 @@ const clientSession = async ({
     sid: string;
     ice: ICEServer[];
     send: (e: OutgoingMessage) => void;
-    onTrack: (s: MediaStream) => void;
+    onTrack: (s: MediaStream, k: string) => void;
     done: () => void;
 }): Promise<RTCPeerConnection> => {
     console.log('ice', ice);
@@ -144,9 +145,10 @@ const clientSession = async ({
         }
     };
     peer.ontrack = (event) => {
+        const kind = event.track.kind;
         const stream = new MediaStream();
         stream.addTrack(event.track);
-        onTrack(stream);
+        onTrack(stream, kind);
     };
 
     return peer;
@@ -229,22 +231,38 @@ export const useRoom = (config: UIConfig): UseRoom => {
                                             : current
                                     );
                                 },
-                                onTrack: (stream) =>
-                                    setState((current) =>
-                                        current
-                                            ? {
-                                                  ...current,
-                                                  clientStreams: [
-                                                      ...current.clientStreams,
-                                                      {
-                                                          id: sid,
-                                                          stream,
-                                                          peer_id: peer,
-                                                      },
-                                                  ],
-                                              }
-                                            : current
-                                    ),
+                                onTrack: (stream, kind) =>
+                                    setState((current) => {
+                                        if (!current) {
+                                            return current;
+                                        }
+
+                                        const isVideo = kind === 'video';
+
+                                        const existingStream = current.clientStreams.find(({id}) => id === sid);
+                                        if (existingStream) {
+                                            if (isVideo) {
+                                                existingStream.videoStream = stream;
+                                            } else {
+                                                existingStream.audioStream = stream;
+                                            }
+
+                                            return current;
+                                        }
+
+                                        return {
+                                            ...current,
+                                            clientStreams: [
+                                                ...current.clientStreams, 
+                                                {
+                                                    id: sid,
+                                                    peer_id: peer,
+                                                    videoStream: isVideo ? stream : undefined,
+                                                    audioStream: isVideo ? undefined : stream
+                                                }
+                                            ]
+                                        }
+                                    }),
                             }).then((peer) => (client.current[event.payload.id] = peer));
                             return;
                         case 'clientice':
@@ -327,6 +345,7 @@ export const useRoom = (config: UIConfig): UseRoom => {
         }
         stream.current = await navigator.mediaDevices.getDisplayMedia({
             video: {frameRate: loadSettings().framerate},
+            audio: true,
         });
         stream.current?.getVideoTracks()[0].addEventListener('ended', () => stopShare());
         setState((current) => (current ? {...current, hostStream: stream.current} : current));


### PR DESCRIPTION
I understand that Screego aims to remain extremely simple, and that audio support was previously closed in issue #102. However, in my daily work, I find it inconvenient not to be able to share audio when I need to demonstrate code and its results to colleagues. As a game programmer, a lot of sound is produced as a result of my code. Not being able to convey this to my colleagues is a significant drawback.

Considering the context of issue #102, I have implemented a slightly different concept, which I will explain below.

## Audio Transmission Settings
![image](https://github.com/screego/server/assets/20394825/2d54d312-486b-4f4e-9825-a708d6a0aa64)

In the browser menu, users can choose whether to share audio. If enabled, both video and audio tracks will be sent; if disabled, only the video track will be sent. In browsers that do not support audio sharing, such as Firefox, this menu will not be displayed, and only the video track will always be sent.

## Audio Listening Settings
First, audio can only be listened to under the following conditions:

1. It is not the hostStream.
2. It is the selectedStream.
3. The "Hear Audio" button is enabled.

The reason for 1 is straightforward—nobody wants to hear their own screen's audio twice.

For 2, the concept of this implementation is the reason. When receiving multiple screens, I couldn't think of a useful scenario where overlapping audio is helpful. Also, having many mute buttons displayed would not be simple. Therefore, by limiting the audio track used for playback to the selected stream, users can choose which audio to hear.

For 3, this is the only additional button in this implementation. With just 2, you can choose which audio to hear but cannot choose not to hear any audio at all. So, I added a button to the control menu to toggle the audio on and off. The default state is Mute. If the selected stream is your own screen or does not include an audio track, the button will automatically be disabled.

![image](https://github.com/screego/server/assets/20394825/7ab0f8a4-9d2b-475a-95b9-f573a975d3c1)
![image](https://github.com/screego/server/assets/20394825/9ee26c8b-53ee-41e3-90b9-7e3008ce7f19)
![image](https://github.com/screego/server/assets/20394825/0b23587d-628f-4bef-a153-2ca953f66512)

Of course, even in browsers that do not support audio sharing, such as Firefox, you can still receive audio.

I believe this approach maintains simplicity.