### PR TITLE
add ghcr badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,10 @@
 <p align="center">
     <a href="https://github.com/screego/server/actions?query=workflow%3Abuild">
         <img alt="Build Status" src="https://github.com/screego/server/workflows/build/badge.svg">
-    </a>
+    </a> 
+    <a href="https://github.com/screego/server/pkgs/container/server">
+        <img alt="Build Status" src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fipitio%2Fghcr-pulls%2Fmaster%2Findex.json&query=%24%5B%3F(%40.owner%3D%3D%22screego%22%20%26%26%20%40.repo%3D%3D%22server%22%20%26%26%20%40.image%3D%3D%22server%22)%5D.pulls&logo=github&label=pulls">
+    </a> 
     <a href="https://goreportcard.com/report/github.com/screego/server">
         <img alt="Go Report Card" src="https://goreportcard.com/badge/github.com/screego/server">
     </a>


### PR DESCRIPTION
ghcr.io's api doesn't let you see the pull count so I created [ghcr-pulls](https://github.com/ipitio/ghcr-pulls), a daily scraper that updates the count and makes this badge possible. I noticed that you use ghcr and have a docker hub counter and thought you might find this useful.