### PR TITLE
Add support for riscv64

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,6 +25,9 @@ builds:
     goarm:
       - "6"
       - "7"
+    ignore:
+      - goos: windows
+        goarch: arm
     flags:
       - '-tags="netgo osusergo"'
     ldflags:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,6 +21,7 @@ builds:
       - arm64
       - ppc64
       - ppc64le
+      - riscv64
     goarm:
       - "6"
       - "7"
@@ -154,6 +155,24 @@ dockers:
       - "--label=org.opencontainers.image.title={{.ProjectName}}"
       - "--label=org.opencontainers.image.revision={{.FullCommit}}"
       - "--label=org.opencontainers.image.version={{.Version}}"
+  - use: buildx
+    goos: linux
+    goarch: riscv64
+    goarm: ""
+    image_templates:
+      - "screego/server:riscv64-unstable"
+      - "screego/server:riscv64-{{ .RawVersion }}"
+      - "screego/server:riscv64-{{ .Major }}"
+      - "ghcr.io/screego/server:riscv64-unstable"
+      - "ghcr.io/screego/server:riscv64-{{ .RawVersion }}"
+      - "ghcr.io/screego/server:riscv64-{{ .Major }}"
+    dockerfile: Dockerfile
+    build_flag_templates:
+      - "--platform=linux/riscv64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
 docker_manifests:
   - name_template: "ghcr.io/screego/server:unstable"
     image_templates:
@@ -163,6 +182,7 @@ docker_manifests:
       - "ghcr.io/screego/server:armv7-unstable"
       - "ghcr.io/screego/server:armv6-unstable"
       - "ghcr.io/screego/server:ppc64le-unstable"
+      - "ghcr.io/screego/server:riscv64-unstable"
   - name_template: "screego/server:unstable"
     image_templates:
       - "screego/server:amd64-unstable"
@@ -171,6 +191,7 @@ docker_manifests:
       - "screego/server:armv7-unstable"
       - "screego/server:armv6-unstable"
       - "screego/server:ppc64le-unstable"
+      - "screego/server:riscv64-unstable"
   - name_template: "screego/server:{{ .RawVersion }}"
     image_templates:
       - "screego/server:amd64-{{ .RawVersion }}"
@@ -179,6 +200,7 @@ docker_manifests:
       - "screego/server:armv7-{{ .RawVersion }}"
       - "screego/server:armv6-{{ .RawVersion }}"
       - "screego/server:ppc64le-{{ .RawVersion }}"
+      - "screego/server:riscv64-{{ .RawVersion }}"
   - name_template: "ghcr.io/screego/server:{{ .RawVersion }}"
     image_templates:
       - "ghcr.io/screego/server:amd64-{{ .RawVersion }}"
@@ -187,6 +209,7 @@ docker_manifests:
       - "ghcr.io/screego/server:armv7-{{ .RawVersion }}"
       - "ghcr.io/screego/server:armv6-{{ .RawVersion }}"
       - "ghcr.io/screego/server:ppc64le-{{ .RawVersion }}"
+      - "ghcr.io/screego/server:riscv64-{{ .RawVersion }}"
   - name_template: "screego/server:{{ .Major }}"
     image_templates:
       - "screego/server:amd64-{{ .Major }}"
@@ -195,6 +218,7 @@ docker_manifests:
       - "screego/server:armv7-{{ .Major }}"
       - "screego/server:armv6-{{ .Major }}"
       - "screego/server:ppc64le-{{ .Major }}"
+      - "screego/server:riscv64-{{ .Major }}"
   - name_template: "ghcr.io/screego/server:{{ .Major }}"
     image_templates:
       - "ghcr.io/screego/server:amd64-{{ .Major }}"
@@ -203,3 +227,4 @@ docker_manifests:
       - "ghcr.io/screego/server:armv7-{{ .Major }}"
       - "ghcr.io/screego/server:armv6-{{ .Major }}"
       - "ghcr.io/screego/server:ppc64le-{{ .Major }}"
+      - "ghcr.io/screego/server:riscv64-{{ .Major }}"

--- a/docs/install.md
+++ b/docs/install.md
@@ -14,7 +14,7 @@ Setting up Screego with docker is pretty easy, you basically just have to start 
 [ghcr.io/screego/server](https://github.com/orgs/screego/packages/container/package/server) and
 [screego/server](https://hub.docker.com/r/screego/server)
 docker images are multi-arch docker images.
-This means the image will work for `amd64`, `i386`, `ppc64le` (power pc), `arm64`, `armv7` (Raspberry PI) and `armv6`.
+This means the image will work for `amd64`, `i386`, `ppc64le` (power pc), `riscv64`, `arm64`, `armv7` (Raspberry PI) and `armv6`.
 
 By default, Screego runs on port 5050.
 


### PR DESCRIPTION
tested on VisionFive 2 (RVA20)

https://github.com/dongdigua/screego-server/actions/runs/25630910203/artifacts/6904395349